### PR TITLE
fix: preserve one-shot review retry scope

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "agent-validator",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "source": "./",
       "description": "A configurable feedback loop runner for AI-assisted development workflows.",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT"
 }

--- a/.validator/config.yml
+++ b/.validator/config.yml
@@ -12,7 +12,7 @@ cli:
     - github-copilot
   adapters:
     codex:
-      model: gpt-5.5
+      model: gpt-5.6-sol
       allow_tool_use: false
       thinking_budget: low
     github-copilot:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # agent-validator
 
+## 1.13.2
+
+### Patch Changes
+
+- [#145](https://github.com/Codagent-AI/agent-validator/pull/145) Restructure the documentation into focused quickstart, configuration, validation, integration, and reference guides while correcting behavior descriptions against the current implementation.
+
+- [#147](https://github.com/Codagent-AI/agent-validator/pull/147) Preserve the original incremental diff scope when retrying errored one-shot reviews, keep that scope local to the matching review job, and add process-level E2E regression coverage.
+
 ## 1.13.1
 
 ### Patch Changes

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
     },
   },
   "overrides": {
-    "js-yaml": "3.15.0",
+    "js-yaml": "3.15.1",
     "picomatch": "^4.0.4",
   },
   "packages": {
@@ -226,7 +226,7 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "js-yaml": ["js-yaml@3.15.0", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog=="],
+    "js-yaml": ["js-yaml@3.15.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag=="],
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 

--- a/evals/inventory.yml
+++ b/evals/inventory.yml
@@ -305,3 +305,23 @@ issues:
     difficulty: hard
     priority: high
     source: 2026-07-20 agent-runner
+  - id: one-shot-retry-scope-applied-globally
+    file: src/utils/log-parser.ts
+    line_range:
+      - 266
+      - 266
+    description: Recovering the first errored one-shot review scope without filtering by job allows
+      processRerunMode to apply one review's commit or fixBase to every gate in the run, so
+      unrelated checks and reviews can validate the wrong diff and falsely pass.
+    code_snippet: |
+      try {
+        const data = JSON.parse(
+          await fs.readFile(path.join(logDir, candidate.filename), 'utf-8'),
+        ) as ReviewFullJsonOutput;
+        if (data.status === 'error' && data.reviewScope) {
+          return data.reviewScope.changeOptions;
+        }
+    category: bug
+    difficulty: hard
+    priority: high
+    source: 2026-08-30 agent-validator

--- a/evals/inventory.yml
+++ b/evals/inventory.yml
@@ -120,3 +120,106 @@ issues:
     priority: high
     reviewer: error-handling
     source: 2026-03-15 agent-validator
+  - id: pty-drain-timeout-misses-sigkill
+    file: internal/pty/relay.go
+    line_range:
+      - 91
+      - 91
+    description: A PTY drain timeout sends SIGTERM and immediately continues cleanup without checking
+      whether descendants in the command process group exited. A descendant that ignores SIGTERM can
+      remain alive after the runner reports the command outcome, violating the required
+      process-group termination guarantee.
+    code_snippet: >
+      case <-timer.C:
+          drainTimedOut = true
+          outcome.warning = fmt.Sprintf("WARNING: PTY output drain timeout after %s; possible output truncation", config.drainTimeout)
+          _ = config.process.signalGroup(syscall.SIGTERM)
+      }
+
+      if !timer.Stop() {
+    category: bug
+    difficulty: medium
+    priority: high
+    source: 2026-07-17 agent-runner
+  - id: pgid-reuse-kills-unrelated-process-group
+    file: internal/pty/relay.go
+    line_range:
+      - 149
+      - 149
+    description: After the original process group can exit during the grace delay, the relay checks only
+      whether the numeric PGID exists and then sends SIGKILL. If the kernel has reused that PGID,
+      this can kill an unrelated process group because the numeric lookup does not prove process
+      identity.
+    code_snippet: |
+      <-timer.C
+      if config.process.isGroupAlive() {
+          _ = config.process.signalGroup(syscall.SIGKILL)
+      }
+    category: security
+    difficulty: hard
+    priority: high
+    source: 2026-07-17 agent-runner
+  - id: metrics-rehydrate-missing-run-identity-check
+    file: internal/metrics/collector.go
+    line_range:
+      - 312
+      - 312
+    description: Rehydration accepts any schema-v1 metrics artifact without verifying that its run ID
+      and workflow match the collector being initialized. Reusing a session directory for a
+      different run therefore silently merges unrelated metrics and preserves the stale artifact
+      identity while recording the new execution.
+    code_snippet: |
+      if artifact.Steps == nil {
+          artifact.Steps = []StepRecord{}
+      }
+      c.artifact = artifact
+      for i := range artifact.Steps {
+          record := &artifact.Steps[i]
+    category: bug
+    difficulty: medium
+    priority: high
+    source: 2026-07-17 agent-runner
+  - id: claude-filter-silently-drops-oversized-result
+    file: internal/cli/claude.go
+    line_range:
+      - 159
+      - 159
+    description: Claude output filtering uses a bufio.Scanner capped at 1 MiB and never checks
+      scanner.Err(). A valid result event containing more than 1 MiB of response text therefore
+      terminates scanning before the result is yielded and silently returns an empty captured value,
+      causing downstream workflow steps to consume missing or incorrect output.
+    code_snippet: |
+      func (a *ClaudeAdapter) FilterOutput(stdout string) string {
+          var result string
+          scanner := bufio.NewScanner(strings.NewReader(stdout))
+          scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+          for scanner.Scan() {
+              var event struct {
+                  Type   string `json:"type"`
+                  Result string `json:"result"`
+    category: bug
+    difficulty: medium
+    priority: high
+    source: 2026-07-17 agent-runner
+  - id: aggregate-token-field-double-counted
+    file: internal/cli/usage.go
+    line_range:
+      - 47
+      - 47
+    description: The generic token mapper classifies every unknown numeric field as a disjoint other
+      token category. Vendor aggregate fields such as OpenCode total are consequently retained
+      alongside their input, output, reasoning, and cache components, so consumers that sum
+      categories double-count usage and inflate cost estimates.
+    code_snippet: |
+      }
+      canonical, ok := known[vendorKey]
+      if !ok {
+          canonical = "other:" + vendorKey
+      } else {
+          present[vendorKey] = true
+      }
+      tokens[canonical] += count
+    category: bug
+    difficulty: medium
+    priority: high
+    source: 2026-07-17 agent-runner

--- a/evals/inventory.yml
+++ b/evals/inventory.yml
@@ -223,3 +223,85 @@ issues:
     difficulty: medium
     priority: high
     source: 2026-07-17 agent-runner
+  - id: invocation-cwd-used-as-worktree-boundary
+    file: internal/exec/agent.go
+    line_range:
+      - 262
+      - 262
+    description: The agent-call containment boundary is derived from the process invocation directory
+      via os.Getwd() instead of the canonical Git worktree root. When agent-runner starts in an
+      ancestor directory, an agent-controlled workdir can therefore reach sibling repositories or
+      other sensitive descendants; starting in a repository subdirectory also rejects valid paths
+      elsewhere in the same worktree.
+    code_snippet: |
+      if !eligible {
+          return nil, spawnEnv, nil, nil
+      }
+      worktree, worktreeErr := os.Getwd()
+      if worktreeErr != nil {
+          return nil, spawnEnv, nil, fmt.Errorf("resolve parent worktree: %w", worktreeErr)
+      }
+    category: security
+    difficulty: medium
+    priority: high
+    source: 2026-07-20 agent-runner
+  - id: opencode-env-wrapper-windows-startup-failure
+    file: internal/cli/opencode.go
+    line_range:
+      - 84
+      - 84
+    description: The OpenCode agent-call integration always prepends the process invocation with the
+      external Unix `env` executable. Standard Windows installations do not provide that executable,
+      so enabling agent-call integration prevents OpenCode from starting at all on a supported
+      platform.
+    code_snippet: |
+      if !completionEnabled && agentCall == nil {
+          return args, nil
+      }
+      config := make(map[string]any)
+      envArgs := []string{"env"}
+      if completionEnabled {
+          command := input.CompletionCommand.ShellCommand()
+          permission, _ := json.Marshal(map[string]map[string]string{"bash": {command: "allow"}})
+    category: bug
+    difficulty: medium
+    priority: high
+    source: 2026-07-20 agent-runner
+  - id: agent-call-resume-requires-success
+    file: internal/runview/model.go
+    line_range:
+      - 872
+      - 872
+    description: The resume predicate permits agent-call sessions only when their status is success, so
+      inactive failed or aborted calls with a valid CLI session ID cannot be resumed even though
+      they are completed and resumable.
+    code_snippet: |
+      func (m *Model) canResumeAgentSession(n *StepNode) bool {
+          if n == nil || n.SessionID == "" || m.running || m.active {
+              return false
+          }
+          return n.Type != NodeAgentCall || n.Status == StatusSuccess
+      }
+    category: bug
+    difficulty: medium
+    priority: high
+    source: 2026-07-20 agent-runner
+  - id: drilled-call-summary-double-counts-duration
+    file: internal/runview/tree.go
+    line_range:
+      - 379
+      - 379
+    description: The drilled agent-call summary returns the synthetic parent turn and each child call as
+      ordinary sibling rows, causing total aggregation to add child-call durations to the parent's
+      wall-clock duration and overstate elapsed time.
+    code_snippet: |
+      turn.Aborted = n.Aborted
+      turn.Attempts = n.Attempts
+      children := make([]*StepNode, 0, len(n.Children)+1)
+      children = append(children, turn)
+      children = append(children, n.Children...)
+      return children
+    category: bug
+    difficulty: hard
+    priority: high
+    source: 2026-07-20 agent-runner

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "zod": "^4.3.5"
   },
   "overrides": {
-    "js-yaml": "3.15.0",
+    "js-yaml": "3.15.1",
     "picomatch": "^4.0.4"
   }
 }

--- a/src/core/job.ts
+++ b/src/core/job.ts
@@ -3,6 +3,7 @@ import type {
   LoadedConfig,
   LoadedReviewGateConfig,
 } from '../config/types.js';
+import type { ReviewChangeOptions } from '../gates/result.js';
 import type { ExpandedEntryPoint } from './entry-point.js';
 
 export type JobType = 'check' | 'review';
@@ -14,6 +15,7 @@ export interface Job {
   entryPoint: string;
   gateConfig: CheckGateConfig | LoadedReviewGateConfig;
   workingDirectory: string;
+  reviewChangeOptions?: ReviewChangeOptions | null;
 }
 
 /** Check if a gate should run in the current environment. */

--- a/src/core/rerun-review-recovery.ts
+++ b/src/core/rerun-review-recovery.ts
@@ -1,0 +1,39 @@
+import type { LoadedConfig } from '../config/types.js';
+import { findErroredReviewScopes } from '../utils/log-parser.js';
+import { sanitizeJobId } from '../utils/sanitizer.js';
+import { EntryPointExpander } from './entry-point.js';
+import { type Job, JobGenerator } from './job.js';
+
+interface RerunReviewRecoveryContext {
+  config: LoadedConfig;
+  options: {
+    gate?: string;
+    enableReviews?: Set<string>;
+  };
+}
+
+export async function findPreviousErroredReviewJobs(
+  ctx: RerunReviewRecoveryContext,
+): Promise<Job[]> {
+  const scopes = await findErroredReviewScopes(ctx.config.project.log_dir);
+  if (scopes.size === 0) return [];
+
+  const expander = new EntryPointExpander();
+  const jobGen = new JobGenerator(ctx.config, ctx.options.enableReviews);
+  const allEntryPoints = await expander.expandAll(
+    ctx.config.project.entry_points,
+  );
+
+  return jobGen
+    .generateJobs(allEntryPoints)
+    .filter(
+      (job) =>
+        job.type === 'review' &&
+        (!ctx.options.gate || job.name === ctx.options.gate) &&
+        scopes.has(sanitizeJobId(job.id)),
+    )
+    .map((job) => ({
+      ...job,
+      reviewChangeOptions: scopes.get(sanitizeJobId(job.id)) ?? null,
+    }));
+}

--- a/src/core/run-executor-helpers.ts
+++ b/src/core/run-executor-helpers.ts
@@ -29,6 +29,7 @@ import { computeDiffStats } from './diff-stats.js';
 import { EntryPointExpander } from './entry-point.js';
 import { JobGenerator } from './job.js';
 import { findPreviousFailedCheckJobs } from './rerun-check-recovery.js';
+import { findPreviousErroredReviewJobs } from './rerun-review-recovery.js';
 import { findLatestConsoleLog, tryAcquireLock } from './run-executor-lock.js';
 import { Runner } from './runner.js';
 import { TRUSTED_SNAPSHOT_MESSAGE } from './trusted-message.js';
@@ -308,18 +309,25 @@ export async function detectAndPrepareChanges(
 
   log.debug('Detecting changes...');
   const changes = await changeDetector.getChangedFiles();
+  const previousErroredReviewJobs = isRerun
+    ? await findPreviousErroredReviewJobs(ctx)
+    : [];
 
   if (changes.length === 0 && isRerun) {
     const previousFailedCheckJobs = await findPreviousFailedCheckJobs(
       ctx,
       failuresMap,
     );
-    if (previousFailedCheckJobs.length > 0) {
+    const previousFailedJobs = [
+      ...previousFailedCheckJobs,
+      ...previousErroredReviewJobs,
+    ];
+    if (previousFailedJobs.length > 0) {
       log.warn(
-        `No changes detected, but ${previousFailedCheckJobs.length} previous check failure(s) will be re-run.`,
+        `No changes detected, but ${previousFailedJobs.length} previous failed gate(s) will be re-run.`,
       );
       return {
-        jobs: previousFailedCheckJobs,
+        jobs: previousFailedJobs,
         changeOpts: effectiveChangeOptions,
       };
     }
@@ -336,6 +344,10 @@ export async function detectAndPrepareChanges(
     changes,
   );
   let jobs = jobGen.generateJobs(entryPoints);
+  const currentJobIds = new Set(jobs.map((job) => job.id));
+  jobs.push(
+    ...previousErroredReviewJobs.filter((job) => !currentJobIds.has(job.id)),
+  );
 
   if (ctx.options.gate) {
     jobs = jobs.filter((j) => j.name === ctx.options.gate);

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -215,6 +215,10 @@ export class Runner {
       } else {
         // Use sanitized Job ID for lookup because that's what log-parser uses (based on filenames)
         const safeJobId = sanitizeJobId(job.id);
+        const reviewChangeOptions =
+          job.reviewChangeOptions === undefined
+            ? this.changeOptions
+            : (job.reviewChangeOptions ?? undefined);
         result = await this.reviewExecutor.execute(
           job.id,
           job.gateConfig as LoadedReviewGateConfig,
@@ -222,7 +226,7 @@ export class Runner {
           this.logger.createLoggerFactory(job.id),
           effectiveBaseBranch,
           this.previousFailuresMap?.get(safeJobId),
-          this.changeOptions,
+          reviewChangeOptions,
           this.config.project.rerun_new_issue_threshold,
           this.passedSlotsMap?.get(safeJobId),
           this.config.project.log_dir,

--- a/src/gates/result.ts
+++ b/src/gates/result.ts
@@ -10,6 +10,16 @@ export interface PreviousViolation {
   result?: string | null;
 }
 
+export interface ReviewChangeOptions {
+  commit?: string;
+  uncommitted?: boolean;
+  fixBase?: string;
+}
+
+export interface ReviewScope {
+  changeOptions: ReviewChangeOptions | null;
+}
+
 export interface ReviewFullJsonOutput {
   adapter: string;
   timestamp: string;
@@ -23,6 +33,7 @@ export interface ReviewFullJsonOutput {
   violations: PreviousViolation[];
   passIteration?: number; // Only present when status is "skipped_prior_pass"
   preservedFromIteration?: number; // Only present when status is "preserved_one_shot" or preserved fail
+  reviewScope?: ReviewScope; // Present for dispatched one-shot reviews so adapter errors can retry the same diff
 }
 
 export interface GateResult {

--- a/src/gates/review-agg.ts
+++ b/src/gates/review-agg.ts
@@ -1,6 +1,10 @@
 import fs from 'node:fs/promises';
 import { getCategoryLogger } from '../output/app-logger.js';
-import type { GateResult, ReviewFullJsonOutput } from './result.js';
+import type {
+  GateResult,
+  ReviewFullJsonOutput,
+  ReviewScope,
+} from './result.js';
 import type {
   ReviewJsonOutput,
   ReviewOutputEntry,
@@ -171,6 +175,7 @@ export async function writeJsonResult(
   status: 'pass' | 'fail' | 'error',
   rawOutput: string,
   json: ReviewJsonOutput,
+  reviewScope?: ReviewScope,
 ): Promise<string> {
   const jsonPath = logPath.replace(/\.log$/, '.json');
   const fullOutput: ReviewFullJsonOutput = {
@@ -179,6 +184,7 @@ export async function writeJsonResult(
     status,
     rawOutput,
     violations: json.violations || [],
+    reviewScope,
   };
 
   await fs.writeFile(jsonPath, JSON.stringify(fullOutput, null, 2));

--- a/src/gates/review-dispatch-types.ts
+++ b/src/gates/review-dispatch-types.ts
@@ -1,5 +1,5 @@
 import type { AdapterConfig } from '../config/types.js';
-import type { PreviousViolation } from './result.js';
+import type { PreviousViolation, ReviewChangeOptions } from './result.js';
 import type { LoggerBundle, LoggerFactory } from './review-helpers.js';
 import type { ReviewConfig, ReviewOutputEntry } from './review-types.js';
 
@@ -21,6 +21,7 @@ export interface DispatchForDiffArgs {
   logDir?: string;
   adapterConfigs?: Record<string, AdapterConfig>;
   contextContent?: string;
+  changeOptions?: ReviewChangeOptions;
   oneShotOutputs: ReviewOutputEntry[];
   runningSlotIndexes: Set<number>;
 }

--- a/src/gates/review-eval.ts
+++ b/src/gates/review-eval.ts
@@ -6,7 +6,7 @@ import {
 } from '../utils/diff-parser.js';
 import { markAdapterUnhealthy } from '../utils/execution-state.js';
 import { findJsonObjectEnd } from './json-scan.js';
-import type { PreviousViolation } from './result.js';
+import type { PreviousViolation, ReviewScope } from './result.js';
 import { writeJsonResult } from './review-agg.js';
 
 export {
@@ -327,14 +327,8 @@ export async function handleReviewOutput(
   adapterLogger: (msg: string) => Promise<void>,
   mainLogger: (msg: string) => Promise<void>,
   _logDir: string | undefined,
-): Promise<
-  Array<{
-    file: string;
-    line: number | string;
-    issue: string;
-    result?: string | null;
-  }>
-> {
+  reviewScope?: ReviewScope,
+): Promise<PreviousViolation[]> {
   await logErrorAndFilterInfo(evaluation, adapter, adapterLogger, mainLogger);
 
   let skipped: Array<{
@@ -351,6 +345,7 @@ export async function handleReviewOutput(
       output,
       logPath,
       adapterLogger,
+      reviewScope,
     );
   }
 
@@ -386,14 +381,8 @@ async function logParsedResult(
   output: string,
   logPath: string,
   adapterLogger: (msg: string) => Promise<void>,
-): Promise<
-  Array<{
-    file: string;
-    line: number | string;
-    issue: string;
-    result?: string | null;
-  }>
-> {
+  reviewScope?: ReviewScope,
+): Promise<PreviousViolation[]> {
   if (!evaluation.json) return [];
 
   await logViolationWarnings(evaluation.json, adapterLogger);
@@ -404,6 +393,7 @@ async function logParsedResult(
     evaluation.status,
     output,
     evaluation.json,
+    reviewScope,
   );
 
   const skipped = (evaluation.json.violations || [])

--- a/src/gates/review-one-shot.ts
+++ b/src/gates/review-one-shot.ts
@@ -1,14 +1,15 @@
 import fs from 'node:fs/promises';
 import { parseReviewFilename } from '../utils/log-parser-helpers.js';
 import { sanitizeJobId } from '../utils/sanitizer.js';
-import type { ReviewFullJsonOutput } from './result.js';
+import type { ReviewChangeOptions, ReviewFullJsonOutput } from './result.js';
 import type { LoggerFactory } from './review-helpers.js';
 import type { ReviewConfig, ReviewOutputEntry } from './review-types.js';
 
 export interface OneShotState {
   outputs: ReviewOutputEntry[];
   runningSlotIndexes: Set<number>;
-  forceFirstRun: boolean;
+  resetPromptContext: boolean;
+  retryChangeOptions: ReviewChangeOptions | null | undefined;
 }
 
 interface PriorReviewJson {
@@ -30,10 +31,17 @@ export async function prepareOneShotPreservation(opts: {
   const runningSlotIndexes = new Set<number>();
   const { config, logDir } = opts;
   if (!(config.one_shot && logDir)) {
-    return { outputs, runningSlotIndexes, forceFirstRun: false };
+    return {
+      outputs,
+      runningSlotIndexes,
+      resetPromptContext: false,
+      retryChangeOptions: undefined,
+    };
   }
 
-  let forceFirstRun = false;
+  let resetPromptContext = false;
+  let retryChangeOptions: ReviewChangeOptions | null | undefined;
+  let retryScopeRunNumber = -1;
   for (let reviewIndex = 1; reviewIndex <= opts.required; reviewIndex++) {
     const prior = await readLatestReviewJsonForSlot(
       logDir,
@@ -42,14 +50,47 @@ export async function prepareOneShotPreservation(opts: {
     );
     if (!prior || prior.data.status === 'error') {
       runningSlotIndexes.add(reviewIndex);
-      forceFirstRun = true;
+      resetPromptContext = true;
+      if (prior?.data.reviewScope && prior.runNumber > retryScopeRunNumber) {
+        retryChangeOptions = prior.data.reviewScope.changeOptions;
+        retryScopeRunNumber = prior.runNumber;
+      }
       continue;
     }
 
     outputs.push(await writePreservedOneShotLog(prior, reviewIndex, opts));
   }
 
-  return { outputs, runningSlotIndexes, forceFirstRun };
+  return {
+    outputs,
+    runningSlotIndexes,
+    resetPromptContext,
+    retryChangeOptions,
+  };
+}
+
+export async function persistOneShotReviewScope(
+  logPath: string,
+  adapter: string,
+  changeOptions: ReviewChangeOptions | undefined,
+): Promise<void> {
+  const jsonPath = logPath.replace(/\.log$/, '.json');
+  const output: ReviewFullJsonOutput = {
+    adapter,
+    timestamp: new Date().toISOString(),
+    status: 'error',
+    rawOutput: '',
+    violations: [],
+    reviewScope: { changeOptions: changeOptions ?? null },
+  };
+
+  try {
+    await fs.writeFile(jsonPath, JSON.stringify(output, null, 2), {
+      flag: 'wx',
+    });
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+  }
 }
 
 async function readLatestReviewJsonForSlot(
@@ -134,6 +175,7 @@ async function writePreservedOneShotLog(
     rawOutput: '',
     violations,
     preservedFromIteration: prior.runNumber,
+    reviewScope: prior.data.reviewScope,
   };
   await fs.writeFile(jsonPath, JSON.stringify(preservedOutput, null, 2));
 

--- a/src/gates/review-runtime-helpers.ts
+++ b/src/gates/review-runtime-helpers.ts
@@ -25,13 +25,3 @@ export async function invokeAdapter(
     thinkingBudget: adapterCfg?.thinking_budget,
   });
 }
-
-export function omitFixBase(options?: {
-  commit?: string;
-  uncommitted?: boolean;
-  fixBase?: string;
-}): { commit?: string; uncommitted?: boolean; fixBase?: string } | undefined {
-  if (!options?.fixBase) return options;
-  const { fixBase: _fixBase, ...rest } = options;
-  return rest;
-}

--- a/src/gates/review.ts
+++ b/src/gates/review.ts
@@ -5,7 +5,11 @@ import {
 } from '../cli-adapters/index.js';
 import type { AdapterConfig } from '../config/types.js';
 import { getCategoryLogger } from '../output/app-logger.js';
-import type { GateResult, PreviousViolation } from './result.js';
+import type {
+  GateResult,
+  PreviousViolation,
+  ReviewChangeOptions,
+} from './result.js';
 import {
   buildFinalResult,
   emptyDiffResult,
@@ -36,8 +40,11 @@ import {
   type LoggerFactory,
   logSkipMessages,
 } from './review-helpers.js';
-import { prepareOneShotPreservation } from './review-one-shot.js';
-import { invokeAdapter, omitFixBase } from './review-runtime-helpers.js';
+import {
+  persistOneShotReviewScope,
+  prepareOneShotPreservation,
+} from './review-one-shot.js';
+import { invokeAdapter } from './review-runtime-helpers.js';
 import type {
   EvaluationResult,
   ReviewConfig,
@@ -57,11 +64,7 @@ export class ReviewGateExecutor {
     loggerFactory: LoggerFactory,
     baseBranch: string,
     previousFailures?: Map<string, PreviousViolation[]>,
-    changeOptions?: {
-      commit?: string;
-      uncommitted?: boolean;
-      fixBase?: string;
-    },
+    changeOptions?: ReviewChangeOptions,
     rerunThreshold: 'critical' | 'high' | 'medium' | 'low' = 'high',
     passedSlots?: Map<number, { adapter: string; passIteration: number }>,
     logDir?: string,
@@ -108,11 +111,7 @@ export class ReviewGateExecutor {
     logPathsSet: Set<string>,
     startTime: number,
     previousFailures?: Map<string, PreviousViolation[]>,
-    changeOptions?: {
-      commit?: string;
-      uncommitted?: boolean;
-      fixBase?: string;
-    },
+    changeOptions?: ReviewChangeOptions,
     rerunThreshold: 'critical' | 'high' | 'medium' | 'low' = 'high',
     passedSlots?: Map<number, { adapter: string; passIteration: number }>,
     logDir?: string,
@@ -145,10 +144,11 @@ export class ReviewGateExecutor {
       );
     }
 
-    const effectiveChangeOptions = oneShotState.forceFirstRun
-      ? omitFixBase(changeOptions)
-      : changeOptions;
-    const effectivePreviousFailures = oneShotState.forceFirstRun
+    const effectiveChangeOptions =
+      oneShotState.retryChangeOptions === undefined
+        ? changeOptions
+        : (oneShotState.retryChangeOptions ?? undefined);
+    const effectivePreviousFailures = oneShotState.resetPromptContext
       ? undefined
       : previousFailures;
 
@@ -190,6 +190,7 @@ export class ReviewGateExecutor {
       logDir,
       adapterConfigs,
       contextContent,
+      changeOptions: effectiveChangeOptions,
       oneShotOutputs: oneShotState.outputs,
       runningSlotIndexes: oneShotState.runningSlotIndexes,
     });
@@ -249,6 +250,7 @@ export class ReviewGateExecutor {
       args.logDir,
       args.adapterConfigs,
       args.contextContent,
+      args.changeOptions,
       args.oneShotOutputs,
     );
   }
@@ -276,6 +278,7 @@ export class ReviewGateExecutor {
     logDir?: string,
     adapterConfigs?: Record<string, AdapterConfig>,
     contextContent?: string,
+    changeOptions?: ReviewChangeOptions,
     preservedOutputs: ReviewOutputEntry[] = [],
   ): Promise<GateResult> {
     const dispatchMsg = `Dispatching ${required} review(s) via round-robin: ${assignments.map((a) => `${a.adapter}@${a.reviewIndex}`).join(', ')}`;
@@ -309,6 +312,7 @@ export class ReviewGateExecutor {
         logDir,
         adapterConfigs,
         contextContent,
+        changeOptions,
       );
 
     const outputs = await dispatchReviews(
@@ -349,6 +353,7 @@ export class ReviewGateExecutor {
     logDir?: string,
     adapterConfigs?: Record<string, AdapterConfig>,
     contextContent?: string,
+    changeOptions?: ReviewChangeOptions,
   ): Promise<SingleReviewResult | null> {
     const reviewStartTime = Date.now();
     const adapter = getAdapter(toolName);
@@ -377,6 +382,7 @@ export class ReviewGateExecutor {
         toolName,
         reviewStartTime,
         contextContent,
+        changeOptions,
       );
     } catch (error: unknown) {
       return handleReviewError(
@@ -406,10 +412,17 @@ export class ReviewGateExecutor {
     toolName: string,
     reviewStartTime: number,
     contextContent?: string,
+    changeOptions?: ReviewChangeOptions,
   ): Promise<SingleReviewResult | null> {
     await adapterLogger(
       `[START] review:.:${config.name} (${adapter.name}@${reviewIndex})\n`,
     );
+    const reviewScope = config.one_shot
+      ? { changeOptions: changeOptions ?? null }
+      : undefined;
+    if (config.one_shot) {
+      await persistOneShotReviewScope(logPath, adapter.name, changeOptions);
+    }
 
     const indexKey = String(reviewIndex);
     const adapterPreviousViolations =
@@ -462,6 +475,7 @@ export class ReviewGateExecutor {
       adapterLogger,
       mainLogger,
       logDir,
+      reviewScope,
     );
     return {
       adapter: adapter.name,
@@ -480,11 +494,5 @@ export class ReviewGateExecutor {
     return evaluateOutput(output, diff);
   }
 
-  private async getDiff(
-    entryPointPath: string,
-    baseBranch: string,
-    options?: { commit?: string; uncommitted?: boolean; fixBase?: string },
-  ): Promise<string> {
-    return getDiff(entryPointPath, baseBranch, options);
-  }
+  private getDiff = getDiff;
 }

--- a/src/utils/log-parser.ts
+++ b/src/utils/log-parser.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type {
   PreviousViolation,
+  ReviewChangeOptions,
   ReviewFullJsonOutput,
 } from '../gates/result.js';
 import { getCategoryLogger } from '../output/app-logger.js';
@@ -225,6 +226,56 @@ export async function findPreviousFailures(
     }
     return includePassedSlots ? { failures: [], passedSlots: new Map() } : [];
   }
+}
+
+/**
+ * Recover the original change scope for each review job whose latest slot
+ * result is an errored one-shot dispatch.
+ */
+export async function findErroredReviewScopes(
+  logDir: string,
+): Promise<Map<string, ReviewChangeOptions | null>> {
+  let files: string[];
+  try {
+    files = await fs.readdir(logDir);
+  } catch {
+    return new Map();
+  }
+
+  const candidates = files
+    .map((filename) => ({ filename, parsed: parseReviewFilename(filename) }))
+    .filter(
+      (
+        entry,
+      ): entry is {
+        filename: string;
+        parsed: NonNullable<ReturnType<typeof parseReviewFilename>>;
+      } => entry.parsed?.ext === 'json',
+    )
+    .sort((a, b) => b.parsed.runNumber - a.parsed.runNumber);
+  const seenSlots = new Set<string>();
+  const scopes = new Map<string, ReviewChangeOptions | null>();
+
+  for (const candidate of candidates) {
+    const slot = `${candidate.parsed.jobId}@${candidate.parsed.reviewIndex}`;
+    if (seenSlots.has(slot)) continue;
+    seenSlots.add(slot);
+
+    try {
+      const data = JSON.parse(
+        await fs.readFile(path.join(logDir, candidate.filename), 'utf-8'),
+      ) as ReviewFullJsonOutput;
+      if (data.status === 'error' && data.reviewScope) {
+        if (!scopes.has(candidate.parsed.jobId)) {
+          scopes.set(candidate.parsed.jobId, data.reviewScope.changeOptions);
+        }
+      }
+    } catch {
+      // The latest malformed slot cannot safely fall back to an older scope.
+    }
+  }
+
+  return scopes;
 }
 
 /**

--- a/src/utils/log-parser.ts
+++ b/src/utils/log-parser.ts
@@ -271,7 +271,11 @@ export async function findErroredReviewScopes(
         }
       }
     } catch {
-      // The latest malformed slot cannot safely fall back to an older scope.
+      // The latest malformed slot cannot safely fall back to an older scope,
+      // but its job must still rerun rather than silently passing.
+      if (!scopes.has(candidate.parsed.jobId)) {
+        scopes.set(candidate.parsed.jobId, null);
+      }
     }
   }
 

--- a/test/gates/review-one-shot.test.ts
+++ b/test/gates/review-one-shot.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { persistOneShotReviewScope } from "../../src/gates/review-one-shot.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+	);
+});
+
+describe("persistOneShotReviewScope", () => {
+	it("does not replace an existing malformed review result", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "one-shot-scope-"));
+		tempDirs.push(dir);
+		const logPath = path.join(dir, "review.log");
+		const jsonPath = path.join(dir, "review.json");
+		await fs.writeFile(jsonPath, "{malformed");
+
+		await persistOneShotReviewScope(logPath, "codex", {
+			fixBase: "abc123",
+		});
+
+		expect(await fs.readFile(jsonPath, "utf8")).toBe("{malformed");
+	});
+});

--- a/test/gates/review.test.ts
+++ b/test/gates/review.test.ts
@@ -814,7 +814,129 @@ describe("ReviewGateExecutor Rerun Logic", () => {
 		]);
 	});
 
-	it("redispatches a one-shot review with first-run prompt when prior JSON errored", async () => {
+	it("keeps the incremental baseline on the first one-shot dispatch", async () => {
+		logger = new Logger(RERUN_DIR);
+		await logger.init();
+
+		let capturedOptions: { fixBase?: string } | undefined;
+		const executor = new ReviewGateExecutor();
+		// biome-ignore lint/suspicious/noExplicitAny: Patching private method for testing
+		(executor as any).getDiff = async (
+			_entry: string,
+			_base: string,
+			options?: { fixBase?: string },
+		) => {
+			capturedOptions = options;
+			return "mock diff content";
+		};
+
+		const result = await executor.execute(
+			"review:src:task-compliance",
+			{
+				name: "task-compliance",
+				cli_preference: ["mock-adapter"],
+				num_reviews: 1,
+				prompt: "task-compliance",
+				promptContent: "Task compliance",
+				parallel: true,
+				run_in_ci: true,
+				run_locally: true,
+				enabled: true,
+				one_shot: true,
+			},
+			"src/",
+			logger.createLoggerFactory("review:src:task-compliance"),
+			"main",
+			undefined,
+			{ uncommitted: true, fixBase: "narrow-base" },
+			"high",
+			undefined,
+			RERUN_DIR,
+		);
+
+		expect(result.status).toBe("pass");
+		expect(capturedOptions?.fixBase).toBe("narrow-base");
+	});
+
+	it("reuses the original one-shot scope after an adapter error", async () => {
+		logger = new Logger(RERUN_DIR);
+		await logger.init();
+
+		const capturedOptions: Array<{ fixBase?: string } | undefined> = [];
+		let capturedRetryPrompt = "";
+		currentExecute = async () => {
+			throw new Error("adapter failed");
+		};
+
+		const executor = new ReviewGateExecutor();
+		// biome-ignore lint/suspicious/noExplicitAny: Patching private method for testing
+		(executor as any).getDiff = async (
+			_entry: string,
+			_base: string,
+			options?: { fixBase?: string },
+		) => {
+			capturedOptions.push(options);
+			return "mock diff content";
+		};
+
+		const config = {
+			name: "task-compliance",
+			cli_preference: ["mock-adapter"],
+			num_reviews: 1,
+			prompt: "task-compliance",
+			promptContent: "Task compliance",
+			parallel: true,
+			run_in_ci: true,
+			run_locally: true,
+			enabled: true,
+			one_shot: true,
+		};
+
+		const firstResult = await executor.execute(
+			"review:src:task-compliance",
+			config,
+			"src/",
+			logger.createLoggerFactory("review:src:task-compliance"),
+			"main",
+			undefined,
+			{ uncommitted: true, fixBase: "original-base" },
+			"high",
+			undefined,
+			RERUN_DIR,
+		);
+		expect(firstResult.status).toBe("error");
+
+		logger = new Logger(RERUN_DIR);
+		await logger.init();
+		currentExecute = async (request) => {
+			capturedRetryPrompt = (request as { prompt: string }).prompt;
+			return JSON.stringify({ status: "pass", message: "OK" });
+		};
+
+		const retryResult = await executor.execute(
+			"review:src:task-compliance",
+			config,
+			"src/",
+			logger.createLoggerFactory("review:src:task-compliance"),
+			"main",
+			new Map([
+				["1", [{ file: "file.ts", line: 1, issue: "old issue", status: "fixed" as const }]],
+			]),
+			{ uncommitted: true, fixBase: "later-base" },
+			"high",
+			undefined,
+			RERUN_DIR,
+		);
+
+		expect(retryResult.status).toBe("pass");
+		expect(capturedRetryPrompt).not.toContain("RERUN MODE");
+		expect(capturedOptions.map((options) => options?.fixBase)).toEqual([
+			"original-base",
+			"original-base",
+		]);
+	});
+
+	it("redispatches a legacy one-shot error with first-run prompt and current baseline", async () => {
 		await fs.writeFile(
 			path.join(RERUN_DIR, "review_src_task-compliance_mock-adapter@1.1.json"),
 			JSON.stringify({
@@ -877,7 +999,7 @@ describe("ReviewGateExecutor Rerun Logic", () => {
 
 		expect(result.status).toBe("pass");
 		expect(capturedPrompt).not.toContain("RERUN MODE");
-		expect(capturedOptions?.fixBase).toBeUndefined();
+		expect(capturedOptions?.fixBase).toBe("narrow-base");
 	});
 
 	it("does not suppress non-one-shot reviews on rerun", async () => {

--- a/test/integration/helpers.ts
+++ b/test/integration/helpers.ts
@@ -33,6 +33,69 @@ export async function createClaudeStub(): Promise<{
 	};
 }
 
+export interface RecordingCodexStub {
+	binDir: string;
+	captureDir: string;
+	modeFile: string;
+	setMode: (mode: "pass" | "process-error" | "review-fail") => Promise<void>;
+	readCaptures: () => Promise<string[]>;
+	cleanup: () => Promise<void>;
+}
+
+export async function createRecordingCodexStub(): Promise<RecordingCodexStub> {
+	const rootDir = await fs.promises.mkdtemp(
+		path.join(os.tmpdir(), "codex-recording-stub-"),
+	);
+	const binDir = path.join(rootDir, "bin");
+	const captureDir = path.join(rootDir, "captures");
+	const modeFile = path.join(rootDir, "mode");
+	await fs.promises.mkdir(binDir);
+	await fs.promises.mkdir(captureDir);
+	await fs.promises.writeFile(modeFile, "pass\n");
+
+	const codexPath = path.join(binDir, "codex");
+	await fs.promises.writeFile(
+		codexPath,
+		`#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const captureDir = process.env.FAKE_CODEX_CAPTURE_DIR;
+const modeFile = process.env.FAKE_CODEX_MODE_FILE;
+const input = fs.readFileSync(0, "utf8");
+const captureNumber = fs.readdirSync(captureDir).filter((file) => file.startsWith("input-")).length + 1;
+fs.writeFileSync(path.join(captureDir, \`input-\${captureNumber}.txt\`), input);
+const mode = fs.readFileSync(modeFile, "utf8").trim();
+if (mode === "process-error") {
+  process.stderr.write("simulated adapter failure\\n");
+  process.exit(17);
+}
+const result = mode === "review-fail"
+  ? { status: "fail", violations: [{ file: "task.ts", line: 2, issue: "Acceptance finding", priority: "high", status: "new" }] }
+  : { status: "pass", message: "Recording adapter pass" };
+process.stdout.write(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: JSON.stringify(result) } }) + "\\n");
+`,
+	);
+	await fs.promises.chmod(codexPath, 0o755);
+
+	return {
+		binDir,
+		captureDir,
+		modeFile,
+		setMode: (mode) => fs.promises.writeFile(modeFile, `${mode}\n`),
+		readCaptures: async () => {
+			const files = (await fs.promises.readdir(captureDir)).sort((a, b) =>
+				a.localeCompare(b, undefined, { numeric: true }),
+			);
+			return Promise.all(
+				files.map((file) =>
+					fs.promises.readFile(path.join(captureDir, file), "utf8"),
+				),
+			);
+		},
+		cleanup: () => fs.promises.rm(rootDir, { recursive: true, force: true }),
+	};
+}
+
 export async function initGitRepo(dir: string): Promise<void> {
 	const proc = Bun.spawn(
 		[

--- a/test/integration/one-shot-review-e2e.test.ts
+++ b/test/integration/one-shot-review-e2e.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+	createRecordingCodexStub,
+	initGitRepo,
+	isDistBuilt,
+	type RecordingCodexStub,
+	spawnValidator,
+} from "./helpers.js";
+
+const TIMEOUT_MS = 60_000;
+const tempDirs: string[] = [];
+const stubs: RecordingCodexStub[] = [];
+let canRun: boolean;
+
+beforeAll(() => {
+	canRun = isDistBuilt();
+});
+
+afterEach(async () => {
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+	);
+	await Promise.all(stubs.splice(0).map((stub) => stub.cleanup()));
+});
+
+async function createReviewRepo(includeOrdinaryReview = false): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "validator-review-e2e-"));
+	tempDirs.push(dir);
+	await fs.mkdir(path.join(dir, ".validator"));
+	const ordinaryReview = includeOrdinaryReview
+		? `
+      - all-reviewers:
+          builtin: all-reviewers
+          parallel: false`
+		: "";
+	await fs.writeFile(
+		path.join(dir, ".validator", "config.yml"),
+		`base_branch: main
+log_dir: validator_logs
+allow_parallel: false
+cli:
+  default_preference:
+    - codex
+  adapters:
+    codex:
+      allow_tool_use: false
+entry_points:
+  - path: "."
+    reviews:
+      - task-compliance:
+          builtin: task-compliance
+          parallel: false${ordinaryReview}
+`,
+	);
+	await fs.writeFile(path.join(dir, ".gitignore"), "validator_logs/\n");
+	await fs.writeFile(
+		path.join(dir, "legacy.ts"),
+		'export const legacyBehavior = "baseline";\n',
+	);
+	await fs.writeFile(
+		path.join(dir, "task.ts"),
+		'export const taskBehavior = "initial";\n',
+	);
+	await fs.writeFile(
+		path.join(dir, "other.ts"),
+		'export const otherBehavior = "initial";\n',
+	);
+	await initGitRepo(dir);
+	return dir;
+}
+
+function reviewEnv(stub: RecordingCodexStub): Record<string, string | undefined> {
+	return {
+		...process.env,
+		CI: undefined,
+		GITHUB_ACTIONS: undefined,
+		GITHUB_BASE_REF: undefined,
+		GITHUB_SHA: undefined,
+		PATH: `${stub.binDir}:${process.env.PATH ?? ""}`,
+		FAKE_CODEX_CAPTURE_DIR: stub.captureDir,
+		FAKE_CODEX_MODE_FILE: stub.modeFile,
+	};
+}
+
+async function runTaskCompliance(repo: string, stub: RecordingCodexStub) {
+	return spawnValidator(
+		[
+			"run",
+			"--gate",
+			"task-compliance",
+			"--enable-review",
+			"task-compliance",
+			"--report",
+		],
+		{ cwd: repo, env: reviewEnv(stub), timeoutMs: TIMEOUT_MS },
+	);
+}
+
+async function runAllReviews(repo: string, stub: RecordingCodexStub) {
+	return spawnValidator(
+		["run", "--enable-review", "task-compliance", "--report"],
+		{ cwd: repo, env: reviewEnv(stub), timeoutMs: TIMEOUT_MS },
+	);
+}
+
+async function establishIncrementalSnapshot(
+	repo: string,
+	stub: RecordingCodexStub,
+): Promise<void> {
+	await fs.writeFile(
+		path.join(repo, "legacy.ts"),
+		'export const legacyBehavior = "old branch-wide change";\n',
+	);
+	const result = await runTaskCompliance(repo, stub);
+	expect(result.exitCode).toBe(0);
+	expect(result.stdout).toContain("Status: Passed");
+}
+
+async function setupScenario(includeOrdinaryReview = false): Promise<{
+	repo: string;
+	stub: RecordingCodexStub;
+}> {
+	const repo = await createReviewRepo(includeOrdinaryReview);
+	const stub = await createRecordingCodexStub();
+	stubs.push(stub);
+	await establishIncrementalSnapshot(repo, stub);
+	return { repo, stub };
+}
+
+describe("one-shot review E2E", () => {
+	it(
+		"keeps the incremental scope on first dispatch and adapter-error retry",
+		async () => {
+			if (!canRun) return;
+			const { repo, stub } = await setupScenario();
+			await fs.writeFile(
+				path.join(repo, "task.ts"),
+				'export const taskBehavior = "new task-local change";\n',
+			);
+			await stub.setMode("process-error");
+
+			const failed = await runTaskCompliance(repo, stub);
+			expect(failed.exitCode).toBe(1);
+			const failedJson = JSON.parse(
+				await fs.readFile(
+					path.join(
+						repo,
+						"validator_logs",
+						"review_._task-compliance_codex@1.1.json",
+					),
+					"utf8",
+				),
+			);
+
+			await fs.writeFile(
+				path.join(repo, "task.ts"),
+				'export const taskBehavior = "new task-local change";\nexport const retryAdjustment = true;\n',
+			);
+			await stub.setMode("pass");
+			const retried = await runTaskCompliance(repo, stub);
+			expect(retried.exitCode).toBe(0);
+
+			const captures = await stub.readCaptures();
+			expect(captures).toHaveLength(3);
+			expect(captures[1]).toContain("diff --git a/task.ts b/task.ts");
+			expect(captures[1]).not.toContain("diff --git a/legacy.ts b/legacy.ts");
+			expect(captures[2]).toContain("new task-local change");
+			expect(captures[2]).toContain("retryAdjustment");
+			expect(captures[2]).not.toContain("diff --git a/legacy.ts b/legacy.ts");
+			expect(captures[2]).not.toContain("RERUN MODE");
+
+			const retriedJson = JSON.parse(
+				await fs.readFile(
+					path.join(
+						repo,
+						"validator_logs",
+						"previous",
+						"review_._task-compliance_codex@1.2.json",
+					),
+					"utf8",
+				),
+			);
+			expect(retriedJson.reviewScope).toEqual(failedJson.reviewScope);
+		},
+		{ timeout: TIMEOUT_MS },
+	);
+
+	it(
+		"redispatches an adapter error when no files changed before retry",
+		async () => {
+			if (!canRun) return;
+			const { repo, stub } = await setupScenario();
+			await fs.writeFile(
+				path.join(repo, "task.ts"),
+				'export const taskBehavior = "new task-local change";\n',
+			);
+			await stub.setMode("process-error");
+			expect((await runTaskCompliance(repo, stub)).exitCode).toBe(1);
+
+			await stub.setMode("pass");
+			const retried = await runTaskCompliance(repo, stub);
+			const captures = await stub.readCaptures();
+
+			expect(retried.exitCode).toBe(0);
+			expect(captures).toHaveLength(3);
+			expect(captures[2]).toContain("new task-local change");
+			expect(captures[2]).not.toContain("diff --git a/legacy.ts b/legacy.ts");
+			expect(captures[2]).not.toContain("RERUN MODE");
+		},
+		{ timeout: TIMEOUT_MS },
+	);
+
+	it(
+		"keeps retry scope local to the errored one-shot review",
+		async () => {
+			if (!canRun) return;
+			const { repo, stub } = await setupScenario(true);
+			await fs.writeFile(
+				path.join(repo, "task.ts"),
+				'export const taskBehavior = "errored task change";\n',
+			);
+			await stub.setMode("process-error");
+			expect((await runTaskCompliance(repo, stub)).exitCode).toBe(1);
+
+			await fs.writeFile(
+				path.join(repo, "other.ts"),
+				'export const otherBehavior = "new unrelated change";\n',
+			);
+			await stub.setMode("pass");
+			expect((await runAllReviews(repo, stub)).exitCode).toBe(0);
+
+			const captures = await stub.readCaptures();
+			expect(captures).toHaveLength(4);
+			expect(captures[2]).toContain("errored task change");
+			expect(captures[3]).toContain("new unrelated change");
+			expect(captures[3]).not.toContain("errored task change");
+		},
+		{ timeout: TIMEOUT_MS },
+	);
+
+	it(
+		"preserves a substantive one-shot result without another adapter call",
+		async () => {
+			if (!canRun) return;
+			const { repo, stub } = await setupScenario();
+			await fs.writeFile(
+				path.join(repo, "task.ts"),
+				'export const taskBehavior = "initial";\nexport const reviewedChange = true;\n',
+			);
+			await stub.setMode("review-fail");
+			expect((await runTaskCompliance(repo, stub)).exitCode).toBe(1);
+			expect(await stub.readCaptures()).toHaveLength(2);
+
+			await fs.appendFile(
+				path.join(repo, "task.ts"),
+				"export const postReviewChange = true;\n",
+			);
+			await stub.setMode("pass");
+			const preserved = await runTaskCompliance(repo, stub);
+
+			expect(preserved.exitCode).toBe(1);
+			expect(await stub.readCaptures()).toHaveLength(2);
+			const preservedJson = JSON.parse(
+				await fs.readFile(
+					path.join(
+						repo,
+						"validator_logs",
+						"review_._task-compliance_codex@1.2.json",
+					),
+					"utf8",
+				),
+			);
+			expect(preservedJson.preservedFromIteration).toBe(1);
+		},
+		{ timeout: TIMEOUT_MS },
+	);
+});

--- a/test/integration/one-shot-review-e2e.test.ts
+++ b/test/integration/one-shot-review-e2e.test.ts
@@ -205,6 +205,9 @@ describe("one-shot review E2E", () => {
 			const captures = await stub.readCaptures();
 
 			expect(retried.exitCode).toBe(0);
+			expect(retried.stderr).toContain(
+				"No changes detected, but 1 previous failed gate(s) will be re-run.",
+			);
 			expect(captures).toHaveLength(3);
 			expect(captures[2]).toContain("new task-local change");
 			expect(captures[2]).not.toContain("diff --git a/legacy.ts b/legacy.ts");

--- a/test/utils/log-parser.test.ts
+++ b/test/utils/log-parser.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
 	extractPrefix,
+	findErroredReviewScopes,
 	findPreviousFailures,
 	parseLogFile,
 } from "../../src/utils/log-parser.js";
@@ -218,5 +219,44 @@ Status: FAIL
 		const result = await findPreviousFailures(TEST_DIR, "review");
 		expect(result.length).toBe(1);
 		expect(result[0]!.jobId).toBe("review_src_claude");
+	});
+});
+
+describe("findErroredReviewScopes", () => {
+	beforeEach(async () => {
+		await fs.rm(TEST_DIR, { recursive: true, force: true });
+		await fs.mkdir(TEST_DIR, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await fs.rm(TEST_DIR, { recursive: true, force: true });
+	});
+
+	it("recovers a review job without scope when its latest result is malformed", async () => {
+		await fs.writeFile(
+			path.join(
+				TEST_DIR,
+				"review_._task-compliance_codex@1.1.json",
+			),
+			JSON.stringify({
+				adapter: "codex",
+				timestamp: new Date().toISOString(),
+				status: "error",
+				rawOutput: "",
+				violations: [],
+				reviewScope: { changeOptions: { fixBase: "older-scope" } },
+			}),
+		);
+		await fs.writeFile(
+			path.join(
+				TEST_DIR,
+				"review_._task-compliance_codex@1.2.json",
+			),
+			"{malformed",
+		);
+
+		expect(await findErroredReviewScopes(TEST_DIR)).toEqual(
+			new Map([["review_._task-compliance", null]]),
+		);
 	});
 });


### PR DESCRIPTION
## Summary

- preserve the original incremental diff scope when retrying errored one-shot reviews
- keep recovered retry scope local to the matching review job
- fail closed by redispatching the matching review when its latest result JSON is malformed
- add process-level E2E coverage for changed and no-change retries, mixed gates, and preserved results
- release v1.13.2 with synchronized package and plugin metadata

## Validation

- agent-validate run (Status: Passed; real Codex review found no problems)
- bun run test (696 passed)
- bun run test:e2e (14 passed plus Docker init E2E)
- CI checks from the prior revision passed; refreshed CI is pending